### PR TITLE
Fix x-index for navbar to prevent margin overlap

### DIFF
--- a/apps/web-app/components/Header/index.tsx
+++ b/apps/web-app/components/Header/index.tsx
@@ -18,7 +18,7 @@ const Header = () => {
     const router = useRouter()
 
     return (
-        <div className="relative px-[24px] md:px-[72px] flex flex-row h-[112px] md:justify-between w-full z-10 bg-zulalu-darkBase items-center">
+        <div className="relative px-[24px] md:px-[82px] flex flex-row h-[112px] md:justify-between w-full z-10 bg-zulalu-darkBase items-center">
             {!userInfo && loadingPassport.step !== 0 && (
                 <PassportLoadingModal loadingPassport={loadingPassport} errorPassport={errorPassport} />
             )}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description

"Connect password" would hide behind the margin overlap when the window was smaller than 800px but bigger than 720px in width.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Does this introduce a breaking change?

-   [ ] Yes
-   [x ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
